### PR TITLE
Screener dates now work like intended

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "py-alpaca-api"
-version = "0.5.3"
+version = "0.5.4"
 description = "Python package, for communicating with Alpaca Markets REST API."
 authors = ["TexasCoding <jeff10278@me.com>"]
 license = "MIT"


### PR DESCRIPTION
Last update for the screener class for now.
Dates were not working like I originally intended, for the top gainers and losers functions.
now the days will work as follows:

The start and end days by default will always be:
*  Start = day before previous trading day
*  End = Previous trading day. 